### PR TITLE
fix: replace Mithril with institutional trust model

### DIFF
--- a/docs/architecture/three-tier-cages.md
+++ b/docs/architecture/three-tier-cages.md
@@ -86,7 +86,7 @@ A Plutus validator verifies a credential by:
 
 Any entity capable of computing Blake2b-256 hashes can verify a credential:
 
-1. Obtain a trusted root (via Mithril certificate or direct chain query)
+1. Obtain a trusted root (via institutional CSMT API or direct chain query)
 2. Verify the Merkle proof against the root
 3. Check expiration, schema validity, and any policy-specific rules
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ enabling compact on-chain storage and efficient proof generation.
 - **Multi-authority schemas** — independent schema authorities compete on trust;
   no single entity controls the schema layer
 - **Off-chain verification** — credentials verifiable without a Cardano node,
-  via Merkle proof chains anchored to Mithril certificates
+  via Merkle proof chains anchored to institutionally published UTxO set roots
 
 ## How it works
 
@@ -42,7 +42,7 @@ verifiers, not enforced by the protocol.
 | On-chain validators (Aiken) | [cardano-mpfs-onchain][onchain] | Working |
 | Off-chain service (Haskell) | [cardano-mpfs-offchain][offchain] | Working |
 | Merkle trie library | [haskell-mts][mts] | Working |
-| UTxO set Merkle tree | [cardano-utxo-csmt][csmt] | Working (Mithril bridge pending) |
+| UTxO set Merkle tree | [cardano-utxo-csmt][csmt] | Working |
 | VCR protocol layer | This repository | Design phase |
 
 [w3c-vc]: https://www.w3.org/TR/vc-data-model-2.0/

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,6 @@ functional; the VCR protocol layer is being specified.
 
 | Gap | Description | Blocking |
 |-----|-------------|----------|
-| Mithril bridge | cardano-utxo-csmt does not yet consume Mithril-certified roots | Off-chain verification trust chain |
 | MPFS HTTP API | Phase 5 of cardano-mpfs-offchain (Servant API, Docker deployment) | User-facing credential operations |
 | VCR protocol | This repository — schema/credential encoding, proof bundle format | Everything above MPFS |
 
@@ -43,13 +42,7 @@ functional; the VCR protocol layer is being specified.
 - Off-chain verification library (Haskell, for proof bundle verification)
 - Lightweight verification library (for mobile/browser, minimal dependencies)
 
-## Phase 4: Mithril integration
-
-- Bridge cardano-utxo-csmt to Mithril-certified UTxO snapshots
-- Complete trust chain: Mithril cert → CSMT proof → cage UTxO → credential
-- End-to-end off-chain verification without a Cardano node
-
-## Phase 5: Tooling and deployment
+## Phase 4: Tooling and deployment
 
 - CLI for schema registration and credential operations
 - HTTP API for credential issuance, revocation, and verification

--- a/docs/verification/off-chain.md
+++ b/docs/verification/off-chain.md
@@ -47,14 +47,17 @@ The verifier queries a Cardano node (via N2C or an API) for the cage UTxO and
 reads the root from its datum. This is authoritative but requires network access
 and a trusted node.
 
-### Level 2: Mithril-certified root
+### Level 2: Institutionally certified CSMT root
 
-The verifier obtains a Mithril certificate (signed by a quorum of stake pool
-operators) that certifies the UTxO set. It then verifies the cage UTxO's
-existence in the certified set and reads the root. No full node required — only
-Mithril certificate verification.
+The verifier obtains the current UTxO set Merkle root from a trusted institution
+(e.g. the Cardano Foundation) running [cardano-utxo-csmt][csmt]. It then
+verifies the cage UTxO's existence in the certified set via a CSMT inclusion
+proof and reads the credential root from the datum.
 
-See [Trust Chain](trust-chain.md) for the full Mithril verification path.
+No full node required — only an HTTP request for the CSMT root plus local hash
+verification.
+
+See [Trust Chain](trust-chain.md) for the full verification path.
 
 ### Level 3: Issuer-signed root
 
@@ -70,34 +73,36 @@ holder is presenting in person with government-issued ID).
 
 ## Verification without a node
 
-The complete off-chain verification flow, assuming Level 2 (Mithril):
+The complete off-chain verification flow, assuming Level 2 (institutional CSMT):
 
 ```mermaid
 sequenceDiagram
     participant H as Holder
     participant V as Verifier
-    participant M as Mithril Certificate
+    participant I as Institution (CSMT API)
 
     H->>V: Present proof bundle
-    V->>M: Verify Mithril certificate (SPO quorum signatures)
-    V->>V: Verify cage UTxO exists in certified UTxO set (CSMT proof)
-    V->>V: Extract root from cage UTxO datum
+    V->>I: Fetch current UTxO set Merkle root
+    V->>V: Verify cage UTxO exists in UTxO set (CSMT proof)
+    V->>V: Extract credential root from cage UTxO datum
     V->>V: Verify credential Merkle proof against root
     V->>V: Check expiration, schema, trust policy
     V->>V: Accept or reject
 ```
 
-At no point does the verifier contact a Cardano node. The entire verification
-is local computation over cryptographic proofs.
+The only network interaction is fetching the CSMT root. All proof verification
+is local computation.
 
 ## Offline verification
 
-If the verifier has a cached Mithril certificate and CSMT snapshot, verification
-is fully offline. The tradeoff is freshness — the cached root may be stale. A
-credential revoked after the snapshot was taken will still appear valid.
+If the verifier has a cached CSMT root, verification is fully offline. The
+tradeoff is freshness — the cached root may be stale. A credential revoked
+after the root was fetched will still appear valid.
 
 For time-sensitive credentials, the verifier can set a maximum age for the
-Mithril certificate (e.g. "I only accept certificates less than 1 hour old").
+cached root (e.g. "I only accept roots less than 5 minutes old"). The
+cardano-utxo-csmt service updates with every block (~20 seconds), so near
+real-time freshness is achievable.
 
 ## Multiple credentials
 
@@ -111,9 +116,11 @@ Presentation:
   roots:
     - { cageToken: A, root: ..., csmtProof: [...] }
     - { cageToken: B, root: ..., csmtProof: [...] }
-  mithrilCertificate: ...
+  csmtRoot: ByteArray  -- Single UTxO set root from institution
 ```
 
-One Mithril certificate can anchor multiple CSMT proofs, which anchor multiple
+One CSMT root anchors multiple cage UTxO proofs, which anchor multiple
 credential proofs. The entire bundle is self-contained and independently
-verifiable.
+verifiable (given the trusted CSMT root).
+
+[csmt]: https://github.com/cardano-foundation/cardano-utxo-csmt

--- a/docs/verification/trust-chain.md
+++ b/docs/verification/trust-chain.md
@@ -1,45 +1,34 @@
 # Trust Chain
 
 The central challenge of off-chain verification is: how does a verifier trust
-that a Merkle root is authentic? The answer is a chain of Merkle proofs, three
-levels deep, anchored to Cardano's consensus.
+that a Merkle root is authentic? The answer is a chain of Merkle proofs, two
+levels deep, anchored to an institutionally provided UTxO set root.
 
 ## The chain
 
 ```
-Mithril Certificate (SPO quorum signature)
-  └─ UTxO Set Merkle Root (cardano-utxo-csmt)
-       └─ Cage UTxO exists (CSMT inclusion proof)
-            └─ Credential Trie Root (in cage UTxO datum)
-                 └─ Credential exists (MPF inclusion proof)
+UTxO Set Merkle Root (cardano-utxo-csmt, published by Cardano institution)
+  └─ Cage UTxO exists (CSMT inclusion proof)
+       └─ Credential Trie Root (in cage UTxO datum)
+            └─ Credential exists (MPF inclusion proof)
 ```
 
 Each level is independently verifiable. A verifier traverses the chain from top
 to bottom, checking each proof against the level above.
 
-## Level 1: Mithril certificate
-
-[Mithril][mithril] is a stake-based threshold multi-signature protocol for
-Cardano. Stake pool operators (SPOs) sign snapshots of the ledger state. A
-certificate is valid when a quorum of stake-weighted signatures is reached.
-
-The Mithril certificate provides:
-
-- A **UTxO set Merkle root**: the root of a Merkle tree containing every UTxO
-  in the Cardano ledger at a specific slot
-- **Slot number**: when the snapshot was taken
-- **SPO signatures**: cryptographic proof of consensus
-
-**Trust basis**: the same set of SPOs that produce Cardano blocks. If you trust
-Cardano's consensus, you trust Mithril certificates.
-
-## Level 2: UTxO set Merkle tree (CSMT)
+## Level 1: UTxO set Merkle tree (CSMT)
 
 [cardano-utxo-csmt][csmt] maintains a Compact Sparse Merkle Tree over
-Cardano's entire UTxO set. Given the Mithril-certified root, a CSMT inclusion
-proof demonstrates that a specific UTxO exists in the set.
+Cardano's entire UTxO set. It synchronizes with a Cardano node in real time,
+tracking every UTxO creation and consumption.
 
-The proof demonstrates:
+The CSMT root is published by a trusted institution (e.g. the Cardano
+Foundation). Verifiers trust this root based on the institution's reputation and
+operational integrity — the same kind of institutional trust that underpins
+certificate authorities in TLS.
+
+Given a trusted CSMT root, an inclusion proof demonstrates that a specific UTxO
+exists in the set:
 
 - The cage UTxO (identified by transaction ID + output index) **exists**
 - The UTxO is at the expected script address
@@ -48,13 +37,18 @@ The proof demonstrates:
 **Proof size**: O(log n) where n is the total number of UTxOs on Cardano
 (currently ~15 million).
 
-!!! warning "Current status"
-    The bridge between Mithril certificates and cardano-utxo-csmt is **not yet
-    implemented**. This is the critical gap in the trust chain. The CSMT service
-    works independently (maintains the tree, generates proofs), but does not yet
-    consume Mithril-certified roots.
+### Root distribution
 
-## Level 3: Credential trie (MPF)
+The institution publishes the current CSMT root via an HTTP API. Verifiers
+query this endpoint to obtain the root they verify proofs against. The root
+changes with every block as UTxOs are created and consumed.
+
+Multiple institutions could independently run cardano-utxo-csmt instances and
+publish roots. A verifier can cross-check roots from multiple sources for
+additional assurance — if two independent instances agree on the root, the
+probability of corruption is negligible.
+
+## Level 2: Credential trie (MPF)
 
 The cage UTxO datum contains the credential trie root (32 bytes, Blake2b-256).
 An MPF (Merkle Patricia Forestry) inclusion proof demonstrates that a specific
@@ -74,12 +68,12 @@ trie.
 A verifier with a proof bundle performs:
 
 ```
-verify(mithrilCert, csmtProof, cageUtxo, credentialProof, key, value):
+verify(csmtRoot, csmtProof, cageUtxo, credentialProof, key, value):
 
-  1. Check mithrilCert.signatures against known SPO keys
-     → obtain utxoSetRoot
+  1. Obtain csmtRoot from trusted institution
+     → the current UTxO set Merkle root
 
-  2. Verify csmtProof for cageUtxo against utxoSetRoot
+  2. Verify csmtProof for cageUtxo against csmtRoot
      → confirm cage UTxO exists, extract datum
 
   3. Extract credentialRoot from datum
@@ -91,18 +85,18 @@ verify(mithrilCert, csmtProof, cageUtxo, credentialProof, key, value):
      → accept or reject
 ```
 
-Total computation: three rounds of hash verification. No network access. No
-Cardano node. Runnable on any device.
+Total computation: two rounds of hash verification plus one HTTP request for the
+root. Runnable on any device.
 
 ## Proof sizes
 
 | Level | Tree size | Proof steps | Hash size |
 |-------|-----------|-------------|-----------|
-| Mithril | ~3,000 SPOs | ~12 | 32 bytes |
 | CSMT | ~15M UTxOs | ~24 | 32 bytes |
 | MPF | Varies per issuer | ~20 (for 1M credentials) | 32 bytes |
 
-Total proof bundle: approximately 2-3 KB for a single credential verification.
+Total proof bundle: approximately 1-2 KB for a single credential verification
+(excluding the CSMT root itself, which is obtained separately).
 
 ## Non-membership proofs
 
@@ -114,18 +108,21 @@ The same trust chain supports non-membership proofs at every level:
 This enables verifiers to prove negative claims — a capability that EAS on
 Ethereum fundamentally cannot offer.
 
-## Freshness vs completeness
+## Freshness
 
-The trust chain provides a snapshot at a specific slot. Credentials issued or
-revoked after the Mithril snapshot will not be reflected.
+The CSMT root reflects a specific point in time (a specific slot/block).
+Credentials issued or revoked after the root was published will not be
+reflected until the root is updated.
 
 Verifiers control the tradeoff:
 
-- **High freshness**: require recent Mithril certificates (< 1 hour old),
-  or fall back to direct chain query
-- **High availability**: accept older certificates, tolerating some staleness
-- **Mixed**: use Mithril for existence proofs (credential was valid at slot X),
-  use direct query for revocation checks (is it still valid now?)
+- **High freshness**: query the institution's API for the latest root before
+  each verification
+- **Cached**: use a recently fetched root, tolerating some staleness
+- **Mixed**: use cached roots for existence proofs (credential was valid at
+  slot X), query fresh roots for revocation checks (is it still valid now?)
 
-[mithril]: https://github.com/input-output-hk/mithril
+The cardano-utxo-csmt service updates its root with every new block (~20
+seconds on Cardano mainnet), so freshness is bounded by block time.
+
 [csmt]: https://github.com/cardano-foundation/cardano-utxo-csmt


### PR DESCRIPTION
## Summary

- Remove all Mithril references from the trust chain documentation
- Trust anchor is institutional: Cardano Foundation (or similar) publishes the CSMT root via cardano-utxo-csmt HTTP API
- Simplify trust chain to two levels: CSMT proof → MPF proof
- Remove Mithril integration phase from roadmap
- Update off-chain verification flow diagrams

## Test plan

- [ ] MkDocs builds with `--strict`