### PR TITLE
docs: add W3C crosslinks to all pages

### DIFF
--- a/docs/architecture/credential-issuers.md
+++ b/docs/architecture/credential-issuers.md
@@ -34,12 +34,12 @@ key = blake2b_256(schema_uid ++ recipient ++ nonce)
 
 | Field | W3C Equivalent | Description |
 |-------|---------------|-------------|
-| `schema` | `credentialSchema` | Points to a schema in a schema authority's trie. The issuer's choice of schema authority is itself a trust signal. |
-| `recipient` | `credentialSubject` | The entity the credential is about. May differ from the holder (e.g. a parent holds a child's credential). |
+| `schema` | [`credentialSchema`][w3c-schemas] | Points to a schema in a schema authority's trie. The issuer's choice of schema authority is itself a trust signal. |
+| `recipient` | [`credentialSubject`][w3c-subject] | The entity the credential is about. May differ from the [holder][w3c-holder] (e.g. a parent holds a child's credential). |
 | `refUID` | (referenced credentials) | Optional reference to another credential, possibly in a different issuer's cage. Enables credential graphs (e.g. a professional certification that references an academic degree). |
-| `expiration` | `validUntil` | Optional expiration timestamp. Off-chain verifiers check this; on-chain verifiers can check via validity ranges. |
-| `data` | (claim data) | The actual credential claims, encoded according to the referenced schema. |
-| `time` | `validFrom` | Issuance timestamp. |
+| `expiration` | [`validUntil`][w3c-validity] | Optional expiration timestamp. Off-chain verifiers check this; on-chain verifiers can check via validity ranges. |
+| `data` | ([claims][w3c-claims]) | The actual credential claims, encoded according to the referenced schema. |
+| `time` | [`validFrom`][w3c-validity] | Issuance timestamp. |
 
 ## Operations
 
@@ -133,3 +133,9 @@ Verifiers must check the `expiration` field:
 
 The issuer may periodically clean up expired credentials via Delete operations
 to keep the trie compact.
+
+[w3c-schemas]: https://www.w3.org/TR/vc-data-model-2.0/#data-schemas
+[w3c-subject]: https://www.w3.org/TR/vc-data-model-2.0/#credential-subject
+[w3c-holder]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders
+[w3c-validity]: https://www.w3.org/TR/vc-data-model-2.0/#validity-period
+[w3c-claims]: https://www.w3.org/TR/vc-data-model-2.0/#claims

--- a/docs/architecture/on-off-chain.md
+++ b/docs/architecture/on-off-chain.md
@@ -1,7 +1,11 @@
 # On-chain and Off-chain Credentials
 
-Cardano VCR supports three credential modes, each offering a different tradeoff
-between privacy, verifiability, and on-chain cost.
+The W3C specification supports both [embedded and enveloping proofs][w3c-securing]
+as securing mechanisms. Cardano VCR extends this with three credential modes,
+each offering a different tradeoff between privacy, verifiability, and on-chain
+cost.
+
+[w3c-securing]: https://www.w3.org/TR/vc-data-model-2.0/#securing-mechanisms
 
 ## Mode 1: On-chain credentials
 

--- a/docs/architecture/schema-authorities.md
+++ b/docs/architecture/schema-authorities.md
@@ -1,7 +1,8 @@
 # Schema Authorities
 
-Schema authorities manage registries of credential schemas. Each authority
-operates an independent MPFS cage with its own governance policy.
+Schema authorities manage registries of [credential schemas][w3c-schemas]. Each
+authority operates an independent MPFS cage with its own governance policy,
+functioning as a [verifiable data registry][w3c-registry] in W3C terms.
 
 ## Why multiple authorities?
 
@@ -108,3 +109,6 @@ To verify that a credential's schema is valid:
 
 This is the same proof mechanism used for credentials — consistent across the
 entire protocol.
+
+[w3c-schemas]: https://www.w3.org/TR/vc-data-model-2.0/#data-schemas
+[w3c-registry]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-data-registries

--- a/docs/architecture/three-tier-cages.md
+++ b/docs/architecture/three-tier-cages.md
@@ -1,7 +1,9 @@
 # Three-Tier Cage Architecture
 
 Cardano VCR uses three tiers of MPFS cages, each serving a distinct role in the
-credential lifecycle.
+[credential lifecycle][w3c-ecosystem]. The tiers map to the W3C roles:
+[issuers][w3c-issuer], [holders][w3c-holder], and [verifiers][w3c-verifier],
+with cages acting as [verifiable data registries][w3c-registry].
 
 ## Overview
 
@@ -123,3 +125,9 @@ sequenceDiagram
     V->>V: Non-membership proof (revoked)
     A->>C: End (burn cage token, destroy instance)
 ```
+
+[w3c-ecosystem]: https://www.w3.org/TR/vc-data-model-2.0/#ecosystem-overview
+[w3c-issuer]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers
+[w3c-holder]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders
+[w3c-verifier]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier
+[w3c-registry]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-data-registries

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,8 @@
 # Cardano VCR
 
-**Verifiable Credential Registry** — a [W3C Verifiable Credentials Data Model 2.0][w3c-vc]
-implementation on Cardano, built on [Merkle Patricia Forestry (MPFS)][mpfs].
+**Verifiable Credential Registry** — a
+[W3C Verifiable Credentials Data Model 2.0][w3c-vc] implementation on Cardano,
+built on [Merkle Patricia Forestry (MPFS)][mpfs].
 
 ## What is this?
 
@@ -12,8 +13,8 @@ enabling compact on-chain storage and efficient proof generation.
 
 ## Key properties
 
-- **W3C compliant** — implements the Verifiable Credentials Data Model 2.0, not a
-  proprietary attestation format
+- **W3C compliant** — implements the [Verifiable Credentials Data Model 2.0][w3c-vc],
+  not a proprietary attestation format
 - **Merkle proof verification** — any Plutus validator or off-chain entity can
   verify credentials via compact inclusion proofs
 - **Proof of non-membership** — can prove a credential does NOT exist (revocation
@@ -27,9 +28,9 @@ enabling compact on-chain storage and efficient proof generation.
 
 Cardano VCR uses three tiers of [MPFS cages](architecture/three-tier-cages.md):
 
-1. **Schema authorities** manage schema registries (mostly append-only)
-2. **Credential issuers** manage credential tries (insert + revoke)
-3. **Verifiers** consume Merkle proofs (on-chain or off-chain)
+1. **[Schema authorities][w3c-registry]** manage schema registries (mostly append-only)
+2. **[Credential issuers][w3c-issuer]** manage credential tries (insert + revoke)
+3. **[Verifiers][w3c-verifier]** consume Merkle proofs (on-chain or off-chain)
 
 Each tier is a separate MPFS cage instance. Cages are independent — a compromised
 or rogue authority only affects its own data. Trust is a policy decision made by
@@ -46,6 +47,9 @@ verifiers, not enforced by the protocol.
 | VCR protocol layer | This repository | Design phase |
 
 [w3c-vc]: https://www.w3.org/TR/vc-data-model-2.0/
+[w3c-issuer]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers
+[w3c-verifier]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier
+[w3c-registry]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-data-registries
 [mpfs]: https://github.com/cardano-foundation/cardano-mpfs-onchain
 [onchain]: https://github.com/cardano-foundation/cardano-mpfs-onchain
 [offchain]: https://github.com/paolino/cardano-mpfs-offchain

--- a/docs/protocol/eas-comparison.md
+++ b/docs/protocol/eas-comparison.md
@@ -135,12 +135,22 @@ However, this is not a limitation in practice:
 EAS is an Ethereum-specific system. It does not implement the W3C VC standard,
 though there is an [open issue requesting W3C VC support][eas-w3c-issue].
 
-Cardano VCR implements the W3C Verifiable Credentials Data Model 2.0 directly.
-Every concept in the specification (issuer, holder, verifier, verifiable data
-registry, credential schema, credential status, verifiable presentation) has a
-concrete mapping to the protocol.
+Cardano VCR implements the [W3C Verifiable Credentials Data Model 2.0][w3c-vc]
+directly. Every concept in the specification
+([issuer][w3c-issuer], [holder][w3c-holder], [verifier][w3c-verifier],
+[verifiable data registry][w3c-registry], [credential schema][w3c-schemas],
+[credential status][w3c-status],
+[verifiable presentation][w3c-vp]) has a concrete mapping to the protocol.
 
 See [W3C Alignment](w3c-alignment.md) for the complete mapping.
 
 [eas]: https://attest.org/
 [eas-w3c-issue]: https://github.com/ethereum-attestation-service/eas-contracts/issues/4
+[w3c-vc]: https://www.w3.org/TR/vc-data-model-2.0/
+[w3c-issuer]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers
+[w3c-holder]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders
+[w3c-verifier]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier
+[w3c-registry]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-data-registries
+[w3c-schemas]: https://www.w3.org/TR/vc-data-model-2.0/#data-schemas
+[w3c-status]: https://www.w3.org/TR/vc-data-model-2.0/#status
+[w3c-vp]: https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations

--- a/docs/protocol/overview.md
+++ b/docs/protocol/overview.md
@@ -11,9 +11,10 @@ attestations) are currently managed by centralized systems. Holders do not own
 their credentials. Issuers can silently revoke or alter them. Verifiers must
 contact the issuer to check validity.
 
-The W3C Verifiable Credentials standard addresses this by defining a
-three-party model (issuer, holder, verifier) with cryptographic proofs. Cardano
-VCR implements this standard on Cardano.
+The [W3C Verifiable Credentials][w3c-vc] standard addresses this by defining a
+three-party model ([issuer][w3c-issuer], [holder][w3c-holder],
+[verifier][w3c-verifier]) with cryptographic proofs. Cardano VCR implements
+this standard on Cardano.
 
 ## Design principles
 
@@ -21,8 +22,8 @@ VCR implements this standard on Cardano.
 
 Credentials are meaningful because an authority stands behind them. A university
 issues a degree. A government issues a passport. A hospital issues a medical
-record. The W3C VC specification reflects this — issuers are authoritative
-entities.
+record. The W3C VC specification reflects this — [issuers][w3c-issuer] are
+authoritative entities.
 
 Cardano VCR embraces this model. Each issuer operates their own MPFS cage and
 controls what credentials they issue and revoke. This is not a limitation — it
@@ -44,8 +45,8 @@ creating it. Cardano VCR optimizes for the read/verify path:
 
 No single entity controls the protocol. Schema authorities, credential issuers,
 and verifiers are all independent. Verifiers choose which authorities and issuers
-they trust. The protocol provides the cryptographic machinery; trust is a social
-and policy decision.
+they trust. The protocol provides the cryptographic machinery;
+[trust is a social and policy decision][w3c-trust].
 
 ## Protocol layers
 
@@ -104,3 +105,7 @@ See [On-chain Verification](../verification/on-chain.md) and
 [Off-chain Verification](../verification/off-chain.md).
 
 [w3c-vc]: https://www.w3.org/TR/vc-data-model-2.0/
+[w3c-issuer]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers
+[w3c-holder]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders
+[w3c-verifier]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier
+[w3c-trust]: https://www.w3.org/TR/vc-data-model-2.0/#trust-model

--- a/docs/protocol/w3c-alignment.md
+++ b/docs/protocol/w3c-alignment.md
@@ -6,16 +6,16 @@ concept from the specification to its Cardano VCR counterpart.
 
 ## Ecosystem roles
 
-The W3C specification defines four roles:
+The W3C specification defines four [ecosystem roles][w3c-ecosystem]:
 
 | W3C Role | Definition | Cardano VCR |
 |----------|-----------|-------------|
-| **Issuer** | Asserts claims, creates credentials, transmits to holder | Credential cage oracle (cage token owner) |
-| **Holder** | Possesses credentials, creates presentations | Wallet receiving Merkle proofs |
-| **Verifier** | Receives and processes credentials/presentations | Plutus validator or off-chain entity |
-| **Verifiable Data Registry** | Mediates creation/verification of identifiers, schemas, revocation registries | MPFS cages (both schema and credential) |
+| [**Issuer**][w3c-issuer] | Asserts claims, creates credentials, transmits to holder | Credential cage oracle (cage token owner) |
+| [**Holder**][w3c-holder] | Possesses credentials, creates presentations | Wallet receiving Merkle proofs |
+| [**Verifier**][w3c-verifier] | Receives and processes credentials/presentations | Plutus validator or off-chain entity |
+| [**Verifiable Data Registry**][w3c-registry] | Mediates creation/verification of identifiers, schemas, revocation registries | MPFS cages (both schema and credential) |
 
-The specification states:
+The specification [states][w3c-issuer]:
 
 > "A role an entity can perform by asserting claims about one or more subjects,
 > creating a verifiable credential from these claims, and transmitting it to a
@@ -27,35 +27,35 @@ issuer to their credentials.
 
 ## Credential data model
 
-The W3C specification defines required and optional properties for verifiable
-credentials. Here is how each maps to Cardano VCR:
+The W3C specification defines required and optional properties for
+[verifiable credentials][w3c-vc-concept]. Here is how each maps to Cardano VCR:
 
 ### Required properties
 
 | W3C Property | W3C Requirement | Cardano VCR |
 |-------------|----------------|-------------|
-| `@context` | Must include `https://www.w3.org/ns/credentials/v2` | Encoded in credential value; verifiers know the context from the protocol |
-| `type` | Must include `VerifiableCredential` | Implicit — all trie entries under a credential cage are credentials |
-| `issuer` | Entity asserting claims | Cage token ID identifies the issuer |
-| `credentialSubject` | Entity about which claims are made | Part of the credential trie value |
-| `validFrom` | Issuance timestamp | `time` field in the credential value |
+| [`@context`][w3c-contexts] | Must include `https://www.w3.org/ns/credentials/v2` | Encoded in credential value; verifiers know the context from the protocol |
+| [`type`][w3c-vc-concept] | Must include `VerifiableCredential` | Implicit — all trie entries under a credential cage are credentials |
+| [`issuer`][w3c-issuer-prop] | Entity asserting claims | Cage token ID identifies the issuer |
+| [`credentialSubject`][w3c-subject] | Entity about which claims are made | Part of the credential trie value |
+| [`validFrom`][w3c-validity] | Issuance timestamp | `time` field in the credential value |
 
 ### Optional properties
 
 | W3C Property | Cardano VCR |
 |-------------|-------------|
-| `id` | Trie key = `blake2b(schema_uid ++ recipient ++ nonce)` |
-| `validUntil` | `expiration` field in credential value |
-| `credentialSchema` | Reference to schema authority cage token ID + schema key |
-| `credentialStatus` | **Trie membership IS the status** — present = valid, absent = revoked |
-| `evidence` | Can be included in value or referenced off-chain |
+| [`id`][w3c-identifiers] | Trie key = `blake2b(schema_uid ++ recipient ++ nonce)` |
+| [`validUntil`][w3c-validity] | `expiration` field in credential value |
+| [`credentialSchema`][w3c-schemas] | Reference to schema authority cage token ID + schema key |
+| [`credentialStatus`][w3c-status] | **Trie membership IS the status** — present = valid, absent = revoked |
+| [`evidence`][w3c-evidence] | Can be included in value or referenced off-chain |
 | `proof` | Merkle proof against the cage root |
 | `refreshService` | Not applicable (trie is always current) |
 | `termsOfUse` | Can be encoded in schema or credential metadata |
 
 ### The `credentialStatus` insight
 
-The W3C specification says:
+The W3C specification [says][w3c-status]:
 
 > "When an issuer desires to enable status information for a verifiable
 > credential, they MAY add a `credentialStatus` property."
@@ -73,12 +73,13 @@ This has two advantages over status lists:
 
 ## Verifiable presentations
 
-The specification defines:
+The specification [defines][w3c-presentations]:
 
 > "Data derived from one or more verifiable credentials issued by one or more
 > issuers that is shared with a specific verifier."
 
-In Cardano VCR, a verifiable presentation is a **Cardano transaction** containing:
+In Cardano VCR, a [verifiable presentation][w3c-vp] is a **Cardano transaction**
+containing:
 
 - Multiple **reference inputs** (one per issuer cage, providing the credential
   roots)
@@ -93,7 +94,7 @@ proof package that a verifier processes without blockchain interaction.
 
 ## Trust model
 
-The specification states:
+The specification [states][w3c-trust]:
 
 > "Verifiability of a credential does not imply the truth of claims encoded
 > therein."
@@ -115,7 +116,7 @@ A verifier (Plutus validator or off-chain service) decides:
 
 ## Verifiable Data Registry
 
-The specification defines:
+The specification [defines][w3c-registry]:
 
 > "A system performing a role by mediating creation and verification of
 > identifiers, verification material, schemas, revocation registries, and other
@@ -128,7 +129,7 @@ data in the registry.
 
 ## Securing mechanisms
 
-The specification requires:
+The specification [requires][w3c-securing]:
 
 > "A conforming document MUST be secured by at least one securing mechanism."
 
@@ -150,6 +151,8 @@ verifiability) rather than prescribing specific cryptographic schemes.
 
 ### Conforming issuer
 
+The specification [requires][w3c-conformance]:
+
 > "Produces conforming documents, MUST include all required properties, and MUST
 > secure documents using a securing mechanism."
 
@@ -165,5 +168,27 @@ On-chain verifiers (Plutus validators) verify Merkle proofs against cage roots
 via reference inputs. Off-chain verifiers verify proof bundles against trusted
 roots. Both reject invalid proofs.
 
+<!-- W3C VC Data Model 2.0 references -->
 [w3c-vc]: https://www.w3.org/TR/vc-data-model-2.0/
+[w3c-ecosystem]: https://www.w3.org/TR/vc-data-model-2.0/#ecosystem-overview
+[w3c-issuer]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers
+[w3c-holder]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders
+[w3c-verifier]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier
+[w3c-registry]: https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-data-registries
+[w3c-vc-concept]: https://www.w3.org/TR/vc-data-model-2.0/#verifiable-credentials
+[w3c-contexts]: https://www.w3.org/TR/vc-data-model-2.0/#contexts
+[w3c-identifiers]: https://www.w3.org/TR/vc-data-model-2.0/#identifiers
+[w3c-issuer-prop]: https://www.w3.org/TR/vc-data-model-2.0/#issuer
+[w3c-subject]: https://www.w3.org/TR/vc-data-model-2.0/#credential-subject
+[w3c-validity]: https://www.w3.org/TR/vc-data-model-2.0/#validity-period
+[w3c-schemas]: https://www.w3.org/TR/vc-data-model-2.0/#data-schemas
+[w3c-status]: https://www.w3.org/TR/vc-data-model-2.0/#status
+[w3c-evidence]: https://www.w3.org/TR/vc-data-model-2.0/#evidence
+[w3c-presentations]: https://www.w3.org/TR/vc-data-model-2.0/#presentations
+[w3c-vp]: https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations
+[w3c-trust]: https://www.w3.org/TR/vc-data-model-2.0/#trust-model
+[w3c-securing]: https://www.w3.org/TR/vc-data-model-2.0/#securing-mechanisms
+[w3c-conformance]: https://www.w3.org/TR/vc-data-model-2.0/#conformance
+
+<!-- Related W3C specifications -->
 [bitstring]: https://w3c.github.io/vc-bitstring-status-list/

--- a/docs/verification/on-chain.md
+++ b/docs/verification/on-chain.md
@@ -54,7 +54,7 @@ Transaction:
 ## Verifiable presentations
 
 A single transaction can verify credentials from multiple issuers — this is a
-verifiable presentation in W3C terms:
+[verifiable presentation][w3c-vp] in W3C terms:
 
 ```
 Transaction:
@@ -102,3 +102,5 @@ On-chain verification cost is dominated by Merkle proof verification:
 This is significantly cheaper than cross-contract calls on Ethereum, where
 verifying an EAS attestation requires SLOAD operations on the EAS contract's
 storage.
+
+[w3c-vp]: https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations


### PR DESCRIPTION
## Summary

- Add precise W3C VC Data Model 2.0 section links to all documentation pages
- Every W3C concept (issuer, holder, verifier, registry, schemas, status, presentations, trust model, etc.) links to its exact spec section
- 9 files updated across protocol, architecture, and verification docs

## Test plan

- [ ] MkDocs builds with `--strict`